### PR TITLE
Bug fix; measure chi.

### DIFF
--- a/example/linearresponse.jl
+++ b/example/linearresponse.jl
@@ -1,0 +1,37 @@
+
+module MeasureChi
+
+using ElectronGas
+using ElectronGas.GreenFunc
+using ElectronGas.CompositeGrids
+
+export measure_chi
+
+function measure_chi(F_freq::GreenFunc.MeshArray)
+    F_dlr = F_freq |> to_dlr
+    F_ins = real(dlr_to_imtime(F_dlr, [F_freq.mesh[1].representation.β,])) * (-1)
+    integrand = view(F_ins, 1, :)
+    kgrid = F_ins.mesh[2]
+    return real(CompositeGrids.Interp.integrate1D(integrand, kgrid))
+end
+
+function measure_chi(dim, θ, rs)
+    param = Parameter.rydbergUnit(θ, rs, dim)
+    channel = 0
+    lamu, R_freq, F_freq = BSeq.linearResponse(param, channel)
+    return measure_chi(F_freq)
+end
+
+end
+
+using Test
+using .MeasureChi
+
+@testset "measure chi" begin
+    # println(measure_chi(3, 1e-2, 2.0))
+    dim = 3
+    rs = 3.0
+    beta = [400, 800, 1600] .* 8
+    chi = [measure_chi(dim, 1 / b, rs) for b in beta]
+    println(chi)
+end

--- a/example/linearresponse.jl
+++ b/example/linearresponse.jl
@@ -5,6 +5,8 @@ using ElectronGas
 using ElectronGas.GreenFunc
 using ElectronGas.CompositeGrids
 
+using DelimitedFiles
+
 export measure_chi
 
 function measure_chi(F_freq::GreenFunc.MeshArray)
@@ -19,7 +21,18 @@ function measure_chi(dim, θ, rs)
     param = Parameter.rydbergUnit(θ, rs, dim)
     channel = 0
     lamu, R_freq, F_freq = BSeq.linearResponse(param, channel)
-    return measure_chi(F_freq)
+    result = measure_chi(F_freq)
+    println("1/chi=", 1 / result)
+
+    data = [1 / θ 1 / result channel rs]
+
+    dir = "./run/"
+    fname = "gap_chi_rs$(rs)_l$(channel).txt"
+    open(dir * fname, "a+") do io
+        writedlm(io, data, ' ')
+    end
+
+    return 1 / result
 end
 
 end
@@ -31,7 +44,10 @@ using .MeasureChi
     # println(measure_chi(3, 1e-2, 2.0))
     dim = 3
     rs = 3.0
-    beta = [400, 800, 1600] .* 8
+    num = 18
+    beta = [6.25 * 2^i for i in LinRange(0, num - 1, num)]
+    # num = 18
+    # beta = [6.25 * sqrt(2)^i for i in LinRange(0, num - 1, num)]
     chi = [measure_chi(dim, 1 / b, rs) for b in beta]
     println(chi)
 end

--- a/example/linearresponse.jl
+++ b/example/linearresponse.jl
@@ -12,15 +12,16 @@ export measure_chi
 function measure_chi(F_freq::GreenFunc.MeshArray)
     F_dlr = F_freq |> to_dlr
     F_ins = real(dlr_to_imtime(F_dlr, [F_freq.mesh[1].representation.β,])) * (-1)
-    integrand = view(F_ins, 1, :)
     kgrid = F_ins.mesh[2]
+    integrand = view(F_ins, 1, :)
     return real(CompositeGrids.Interp.integrate1D(integrand, kgrid))
 end
 
-function measure_chi(dim, θ, rs)
+function measure_chi(dim, θ, rs; kwargs...)
     param = Parameter.rydbergUnit(θ, rs, dim)
     channel = 0
-    lamu, R_freq, F_freq = BSeq.linearResponse(param, channel)
+    lamu, R_freq, F_freq = BSeq.linearResponse(param, channel
+        ; kwargs...)
     result = measure_chi(F_freq)
     println("1/chi=", 1 / result)
 
@@ -43,11 +44,13 @@ using .MeasureChi
 @testset "measure chi" begin
     # println(measure_chi(3, 1e-2, 2.0))
     dim = 3
-    rs = 3.0
-    num = 18
-    beta = [6.25 * 2^i for i in LinRange(0, num - 1, num)]
+    rs = 7.0
+    # num = 18
+    # beta = [6.25 * 2^i for i in LinRange(0, num - 1, num)]
+    num = 5
+    beta = [400 * 2^i for i in LinRange(0, num - 1, num)]
     # num = 18
     # beta = [6.25 * sqrt(2)^i for i in LinRange(0, num - 1, num)]
-    chi = [measure_chi(dim, 1 / b, rs) for b in beta]
+    chi = [measure_chi(dim, 1 / b, rs; sigmatype=:g0w0) for b in beta]
     println(chi)
 end

--- a/example/linearresponse.jl
+++ b/example/linearresponse.jl
@@ -47,8 +47,7 @@ using .MeasureChi
     rs = 7.0
     # num = 18
     # beta = [6.25 * 2^i for i in LinRange(0, num - 1, num)]
-    num = 5
-    beta = [400 * 2^i for i in LinRange(0, num - 1, num)]
+    beta = [2000, 2200.0, 2229.78,]
     # num = 18
     # beta = [6.25 * sqrt(2)^i for i in LinRange(0, num - 1, num)]
     chi = [measure_chi(dim, 1 / b, rs; sigmatype=:g0w0) for b in beta]

--- a/src/BSeq.jl
+++ b/src/BSeq.jl
@@ -351,7 +351,7 @@ function linearResponse(param, channel::Int; Euv=100 * param.EF, rtol=1e-10,
 
     R_freq = R_imt |> to_dlr |> to_imfreq
     # println(view(R_freq, :, kF_label))
-    return lamu, R_freq
+    return lamu, R_freq, F_freq
 end
 
 end

--- a/src/BSeq.jl
+++ b/src/BSeq.jl
@@ -201,7 +201,7 @@ with zero incoming momentum and frequency, and ``G^{(2)}(p,\\omega_m)`` is the p
 
 """
 function BSeq_solver(param, G2::GreenFunc.MeshArray, kernel, kernel_ins, qgrids::Vector{CompositeGrid.Composite},
-    Euv; Ntherm=120, rtol=1e-10, α=0.7, source::Union{Nothing,GreenFunc.MeshArray}=nothing,
+    Euv; Ntherm=120, rtol=1e-10, atol=1e-10, α=0.7, source::Union{Nothing,GreenFunc.MeshArray}=nothing,
     source_ins::GreenFunc.MeshArray=GreenFunc.MeshArray([1], G2.mesh[2]; dtype=Float64, data=ones(1, G2.mesh[2].size))
 )
     @unpack dim, kF = param
@@ -255,10 +255,10 @@ function BSeq_solver(param, G2::GreenFunc.MeshArray, kernel, kernel_ins, qgrids:
         if n > Ntherm
             lamu = -1 / (1 + R_kF / kF)
             lamu > 0 && error("α = $α is too small!")
-            err = abs(lamu - lamu0) / abs(lamu + EPS)
+            err = abs(lamu - lamu0)
             # Exit the loop if the iteraction converges
-            lamu >= lamu0 > -1 && err < rtol && break
-            lamu0 <= lamu < -1 && err < rtol && break
+            lamu >= lamu0 > -1 && err < rtol * abs(lamu + EPS) + atol && break
+            lamu0 <= lamu < -1 && err < rtol * abs(lamu + EPS) + atol && break
 
             lamu0 = lamu
         end

--- a/test/BSeq.jl
+++ b/test/BSeq.jl
@@ -3,7 +3,7 @@
         dim, θ, rs = 3, 1e-2, 2.0
         param = Parameter.rydbergUnit(θ, rs, dim)
         channel = 0
-        lamu, R_freq = BSeq.linearResponse(param, channel)
+        lamu, R_freq, F_freq = BSeq.linearResponse(param, channel)
         @test isapprox(lamu, -2.34540, rtol=1e-4)
         # lamu, R_freq = BSeq.linearResponse(param, 1)
         # @test isapprox(lamu, -1.23815, rtol=1e-5)


### PR DESCRIPTION
1. added linearresponse.jl in example. This script test flow of chi, which should also be linear to log(T) and produce the same T_c as flow of R_0. More tests on this still needed before adding this into the main module.
2. fixed a bug when calling linearResponse() from BSeq.jl with sigmatype=:g0w0. Added using ..SelfEnergy and convert produced self-energy function to the same frequency grid as response function to fix.