### PR TITLE
Liam

### DIFF
--- a/src/interaction.jl
+++ b/src/interaction.jl
@@ -685,7 +685,7 @@ function T0maxtrix_imtime(tau::Float64, q::Float64,  param)
     poleterm = - poletermnumerator/ poletermdenominator
     # Integral Terms
 
-    function integrand1(vars, q, tau, param)
+    function integrand1(vars, tau, param)
         me, as = param.me, param.as
         m = me * as^2
         u = vars[1][1]

--- a/src/interaction.jl
+++ b/src/interaction.jl
@@ -612,28 +612,30 @@ function T0matrix(q::Float64, n::Int, param)
     as = 4π * param.as / me
     B = me^(3/2)/(4π)
     if as < 1e-6
-        return as/(1. - as * B * sqrt(Complex(q^2/ (4 * me) - 2π * n/β)))
+        return as/(1. - as * B * sqrt(Complex(q^2/ (4 * me) - 2π * n/β * im)))
     else
-        return 1/((1/as) - B * sqrt(Complex(q^2/ (4 * me) - 2π * n/β)))
+        return 1/((1/as) - B * sqrt(Complex(q^2/ (4 * me) - 2π * n/β * im)))
     end
 end
 
 """
-    function Tmatrix(q::Float64, n::Int, param; ladderfunc=Polarization.Ladder0_FiniteTemp, kwargs...)
+    function Tmatrix(q::Float64, n::Int, param; ladderfunc=Polarization.Ladder0_FiniteTemp, vacuumladderfunc=Polarization.LadderVacuum0_FiniteTemp, kwargs...)
 
 Many-body T-matrix in matsubara frequency. 
 #Arguments:
  - q: total incoming momentum
  - n: matsubara frequency given in integer s.t. Ωn=2πTn (either one frequency or array of frequencies)
  - param: other system parameters
+ - ladderfunc: Particle-particle bubble (ladder-diagram of G0G0)
+ - vacuumladderfunc: Vacuum particle-particle bubble
 """
 
-function Tmatrix(q::Float64, n::Int, param; ladderfunc=Polarization.Ladder0_FiniteTemp, kwargs...)
+function Tmatrix(q::Float64, n::Int, param; ladderfunc=Polarization.Ladder0_FiniteTemp, vacuumladderfunc=Polarization.Ladder0Vacuum_FiniteTemp, kwargs...)
     as = 4π * param.as / param.me
     if param.as < 1e-6
-        return as ./ (1 .+ as * ladderfunc(q, n, param; kwargs...))
+        return as ./ (1 .+ as * (ladderfunc(q, n, param; kwargs...) - vacuumladderfunc(q, n, param; kwargs...)))
     else
-        return 1 ./ (1 / as .+ ladderfunc(q, n, param; kwargs...))
+        return 1 ./ (1 / as .+ (ladderfunc(q, n, param; kwargs...) - vacuumladderfunc(q, n, param; kwargs...)))
     end
 end
 
@@ -649,14 +651,14 @@ Difference between Many-body T-matrix and vacuum two-particle T-matrix in imagin
 - ladderfunc: Particle-Particle bubble (ladder-diagram of G0G0)
 """
 
-function δTmatrix_wrapped(Euv, rtol, sgrid::SGT, param; ladderfunc=Polarization.Ladder0_FiniteTemp, kwargs...) where {SGT}
+function δTmatrix_wrapped(Euv, rtol, sgrid::SGT, param; ladderfunc=Polarization.Ladder0_FiniteTemp, vacuumladderfunc=Polarization.Ladder0Vacuum_FiniteTemp, kwargs...) where {SGT}
     β= param.β
     Ωn_mesh_ph = GreenFunc.ImFreq(β, BOSON; Euv=Euv, rtol=rtol, symmetry=:ph)
     δTmatrix_n = GreenFunc.MeshArray(Ωn_mesh_ph, sgrid; dtype=ComplexF64)
 
     for (ki, k) in enumerate(sgrid)
         for (ni, n) in enumerate(Ωn_mesh_ph.grid)
-            δTmatrix_n[ni, ki] = (Tmatrix(k, n, param; ladderfunc = ladderfunc) - T0matrix(k, n, param))
+            δTmatrix_n[ni, ki] = (Tmatrix(k, n, param; ladderfunc = ladderfunc, vacuumladderfunc = vacuumladderfunc) - T0matrix(k, n, param))
         end
     end
     δTmatrix_tau = δTmatrix_n |> to_dlr |> to_imtime
@@ -664,7 +666,7 @@ function δTmatrix_wrapped(Euv, rtol, sgrid::SGT, param; ladderfunc=Polarization
 end
 
 """
-    function T0maxtrix_wrapped(tau::Float64, q::Float64, param)
+    function T0maxtrix_imtime(tau::Float64, q::Float64, param)
 
 Difference between Many-body T-matrix and vacuum two-particle T-matrix in imaginary time. 
 #Arguments:
@@ -673,7 +675,7 @@ Difference between Many-body T-matrix and vacuum two-particle T-matrix in imagin
 - param: other system parameters
 """
 
-function T0maxtrix_wrapped(tau::Float64, q::Float64,  param)
+function T0maxtrix_imtime(tau::Float64, q::Float64,  param)
     """ Two particle scattering in a vacuum T-matrix in imaginary time """
     β, me, as = param.β, param.me, param.as
     B = me^(3/2)/(4π)

--- a/src/legendreinteraction.jl
+++ b/src/legendreinteraction.jl
@@ -386,11 +386,11 @@ function DCKernel0(param, Euv, rtol, Nk, maxK, minK, order, int_type, spin_state
 end
 
 
-function DCKernel_Ladder(param; Euv=param.EF * 100, rtol=1e-10, Nk=8, maxK=param.kF * 10, minK=param.kF * 1e-7, order=4, int_type=:rpa, spin_state=:auto, kwargs...)
-    return DCKernel_Ladder(param, Euv, rtol, Nk, maxK, minK, order, int_type, spin_state; kwargs...)
+function DCKernel_Ladder_r(param; Euv=param.EF * 100, rtol=1e-10, Nk=8, maxK=param.kF * 10, minK=param.kF * 1e-7, order=4, int_type=:rpa, spin_state=:auto, kwargs...)
+    return DCKernel_Ladder_r(param, Euv, rtol, Nk, maxK, minK, order, int_type, spin_state; kwargs...)
 end
 
-function DCKernel_Ladder(param, Euv, rtol, Nk, maxK, minK, order, int_type, spin_state=:sigma;
+function DCKernel_Ladder_r(param, Euv, rtol, Nk, maxK, minK, order, int_type, spin_state=:sigma;
     kgrid=CompositeGrid.LogDensedGrid(:cheb, [0.0, maxK], [0.0, param.kF], Nk, minK, order),
     kwargs...)
     # use helper function
@@ -417,7 +417,7 @@ function DCKernel_Ladder(param, Euv, rtol, Nk, maxK, minK, order, int_type, spin
 
     # dynamic
     for (ni, n) in enumerate(bdlr.n)
-        helper = helper_function_grid(helper_grid, intgrid, 1, u -> Interaction.Tmatrix(u, n, param; kwargs...), param)
+        helper = helper_function_grid(helper_grid, intgrid, 1, u -> real(Interaction.Tmatrix(u, n, param; kwargs...)), param)
         for (ki, k) in enumerate(kgrid.grid)
             for (pi, p) in enumerate(qgrids[ki].grid)
                 Hp, Hm = Interp.interp1D(helper, helper_grid, k + p), Interp.interp1D(helper, helper_grid, abs(k - p))
@@ -426,7 +426,50 @@ function DCKernel_Ladder(param, Euv, rtol, Nk, maxK, minK, order, int_type, spin
         end
     end
 
-    return DCKernel{ComplexF64}(int_type, spin_state, channel, param, kgrid, qgrids, bdlr, kernel_bare, kernel)
+    return DCKernel(int_type, spin_state, channel, param, kgrid, qgrids, bdlr, kernel_bare, kernel)
+end
+
+function DCKernel_Ladder_i(param; Euv=param.EF * 100, rtol=1e-10, Nk=8, maxK=param.kF * 10, minK=param.kF * 1e-7, order=4, int_type=:rpa, spin_state=:auto, kwargs...)
+    return DCKernel_Ladder_i(param, Euv, rtol, Nk, maxK, minK, order, int_type, spin_state; kwargs...)
+end
+
+function DCKernel_Ladder_i(param, Euv, rtol, Nk, maxK, minK, order, int_type, spin_state=:sigma;
+    kgrid=CompositeGrid.LogDensedGrid(:cheb, [0.0, maxK], [0.0, param.kF], Nk, minK, order),
+    kwargs...)
+    # use helper function
+    @unpack kF, β = param
+    channel = 0
+
+    if spin_state == :sigma
+        # for self-energy, always use ℓ=0
+        channel = 0
+    elseif spin_state == :auto
+        error("not implemented!")
+    end
+
+    bdlr = DLRGrid(Euv, β, rtol, false, :ph)
+    qgrids = [CompositeGrid.LogDensedGrid(:gauss, [0.0, maxK], [k, kF], Nk, minK, order) for k in kgrid.grid]
+    qgridmax = maximum([qg.size for qg in qgrids])
+    #println(qgridmax)
+
+    kernel_bare = zeros(ComplexF64, (length(kgrid.grid), (qgridmax)))
+    kernel = zeros(ComplexF64, (length(kgrid.grid), (qgridmax), length(bdlr.n)))
+
+    helper_grid = CompositeGrid.LogDensedGrid(:cheb, [0.0, 2.1 * maxK], [0.0, kF], 2Nk, 0.01minK, 2order)
+    intgrid = CompositeGrid.LogDensedGrid(:cheb, [0.0, helper_grid[end]], [0.0, kF], 2Nk, 0.01minK, 2order)
+
+    # dynamic
+    for (ni, n) in enumerate(bdlr.n)
+        helper = helper_function_grid(helper_grid, intgrid, 1, u -> imag(Interaction.Tmatrix(u, n, param; kwargs...)), param)
+        for (ki, k) in enumerate(kgrid.grid)
+            for (pi, p) in enumerate(qgrids[ki].grid)
+                Hp, Hm = Interp.interp1D(helper, helper_grid, k + p), Interp.interp1D(helper, helper_grid, abs(k - p))
+                kernel[ki, pi, ni] = (Hp - Hm)
+            end
+        end
+    end
+
+    return DCKernel(int_type, spin_state, channel, param, kgrid, qgrids, bdlr, kernel_bare, kernel)
 end
 
 end

--- a/src/parameter.jl
+++ b/src/parameter.jl
@@ -24,7 +24,7 @@ using ..Parameters
     EF::Float64 = 1.0     #kF^2 / (2me)
     β::Float64 = 200 # bare inverse temperature
     μ::Float64 = 1.0
-    as::Float64 = -2.5   # s-wave scattering length (local contact interaction)
+    as::Float64 = 2.5   # s-wave scattering length (local contact interaction)
 
     # artificial parameters
     Λs::Float64 = 0.0   # Yukawa-type spin-symmetric interaction  ~1/(q^2+Λs)

--- a/src/parameter.jl
+++ b/src/parameter.jl
@@ -24,6 +24,7 @@ using ..Parameters
     EF::Float64 = 1.0     #kF^2 / (2me)
     β::Float64 = 200 # bare inverse temperature
     μ::Float64 = 1.0
+    as::Float64 = 0.0   # s-wave scattering length (local contact interaction)
 
     # artificial parameters
     Λs::Float64 = 0.0   # Yukawa-type spin-symmetric interaction  ~1/(q^2+Λs)
@@ -130,7 +131,7 @@ end
 # end
 
 """
-    function fullUnit(ϵ0, e0, me, EF, β)
+    function fullUnit(ϵ0, e0, me, EF, β, dim=3, spin=2; kwargs...)
 
 generate Para with a complete set of parameters, no value presumed.
 
@@ -140,6 +141,8 @@ generate Para with a complete set of parameters, no value presumed.
  - me: electron mass
  - EF: Fermi energy
  - β: inverse temperature
+- dim: dimension
+- spin: spin
 """
 @inline function fullUnit(ϵ0, e0, me, EF, β, dim=3, spin=2; kwargs...)
     # μ = try

--- a/src/parameter.jl
+++ b/src/parameter.jl
@@ -24,7 +24,7 @@ using ..Parameters
     EF::Float64 = 1.0     #kF^2 / (2me)
     β::Float64 = 200 # bare inverse temperature
     μ::Float64 = 1.0
-    as::Float64 = 1.0   # s-wave scattering length (local contact interaction)
+    as::Float64 = -2.5   # s-wave scattering length (local contact interaction)
 
     # artificial parameters
     Λs::Float64 = 0.0   # Yukawa-type spin-symmetric interaction  ~1/(q^2+Λs)

--- a/src/parameter.jl
+++ b/src/parameter.jl
@@ -24,7 +24,7 @@ using ..Parameters
     EF::Float64 = 1.0     #kF^2 / (2me)
     β::Float64 = 200 # bare inverse temperature
     μ::Float64 = 1.0
-    as::Float64 = 0.0   # s-wave scattering length (local contact interaction)
+    as::Float64 = 1.0   # s-wave scattering length (local contact interaction)
 
     # artificial parameters
     Λs::Float64 = 0.0   # Yukawa-type spin-symmetric interaction  ~1/(q^2+Λs)

--- a/src/polarization.jl
+++ b/src/polarization.jl
@@ -186,7 +186,8 @@ function Ladder0_FiniteTemp(q::Float64, n::Int, param; scaleN=20, minterval=1e-6
     integrand = zeros(ComplexF64, kgrid.size)
     if dim == 3
         for (ki, k) in enumerate(kgrid.grid)
-            if Ωn <1000
+            #integrand[ki] = _LadderT3d_integrand(k, q, Ωn, param)
+            if Ωn <100
                 integrand[ki] = _LadderT3d_integrand(k, q, Ωn, param)
                 @assert !isnan(integrand[ki]) "nan at k=$k, q=$q, n=$n"
             else
@@ -195,7 +196,7 @@ function Ladder0_FiniteTemp(q::Float64, n::Int, param; scaleN=20, minterval=1e-6
         end
     end
     result = Interp.integrate1D(integrand, kgrid)
-    if Ωn> 1000
+    if Ωn> 100
         result = -me^(3 / 2) / (4π) * sqrt(Complex(q^2 / (4me) - 1im * Ωn - 2μ)) # Replace high frequency tail with two-particle particle-particle term
     end
     return result
@@ -207,7 +208,7 @@ function Ladder0_FreeElectron(q::Float64, n::Int, param)
    
         error("No support for finite-temperature polarization in $dim dimension!")
     end
-    return -me^(3 / 2) / (4π) * sqrt(q^2 / (4me) - 1im * 2π * n / β)
+    return -me^(3 / 2) / (4π) * sqrt(q^2 / (4me) - 1im * 2π * n / β - 2μ)
 end
 
 """
@@ -354,6 +355,7 @@ function Ladder0_FiniteTemp(q::Float64, n::AbstractVector, param; scaleN=20, min
         for (ki, k) in enumerate(kgrid.grid)
             for (mi, m) in enumerate(n)
               Ωm = 2π * m / β
+              #integrand[ki, mi] = _LadderT3d_integrand(k, q, Ωm, param)
                 if Ωm < 1000
                     integrand[ki, mi] = _LadderT3d_integrand(k, q, Ωm, param)
                     @assert !isnan(integrand[ki, mi]) "nan at k=$k, q=$q"
@@ -366,7 +368,7 @@ function Ladder0_FiniteTemp(q::Float64, n::AbstractVector, param; scaleN=20, min
     result = Interp.integrate1D(integrand, kgrid; axis=1)
     for (mi, m) in enumerate(n)
        Ωm = 2π * m / β
-        if Ωm > 1000
+        if Ωm > 100
             result[mi] = -me^(3 / 2) / (4π) * sqrt(Complex(q^2 / (4me) - 1im * Ωm - 2μ)) # Replace with two-particle particle-particle high frequency tail
         end
     end
@@ -379,11 +381,11 @@ function Ladder0_FreeElectron(q::Float64, n::AbstractVector, param)
     if dim != 3
         error("No support for finite-temperature polarization in $dim dimension!")
     end
-    integrand = zeros(ComplexF64, length(n))
+    result = zeros(ComplexF64, length(n))
     for (mi, m) in enumerate(n)
-        integrand[mi] = Ladder0_FreeElectron(q, m, param)
+        result[mi] = -me^(3 / 2) / (4π) * sqrt(q^2 / (4me) - 1im * 2π * m / β - 2μ)
     end
-    return integrand
+    return result
 end
 
 

--- a/src/selfenergy.jl
+++ b/src/selfenergy.jl
@@ -273,22 +273,27 @@ function G0Γ0(param, Euv, rtol, Nk, maxK, minK, order, int_type, kgrid::Union{A
         error("No support for G0Γ0 in 2d dimension!")
     elseif dim == 3
         if isnothing(kgrid)
-            kernel = SelfEnergy.LegendreInteraction.DCKernel_Ladder(param;
+            kernel_r = SelfEnergy.LegendreInteraction.DCKernel_Ladder_r(param;
+                Euv=Euv, rtol=rtol, Nk=Nk, maxK=maxK, minK=minK, order=order, int_type=int_type, spin_state=:sigma, kwargs...)
+            kernel_i = SelfEnergy.LegendreInteraction.DCKernel_Ladder_i(param;
                 Euv=Euv, rtol=rtol, Nk=Nk, maxK=maxK, minK=minK, order=order, int_type=int_type, spin_state=:sigma, kwargs...)
         else
             if (kgrid isa AbstractVector)
                 kgrid = SimpleG.Arbitrary{eltype(kgrid)}(kgrid)
             end
-            kernel = SelfEnergy.LegendreInteraction.DCKernel_Ladder(param;
+            kernel_r = SelfEnergy.LegendreInteraction.DCKernel_Ladder_r(param;
+                Euv=Euv, rtol=rtol, Nk=Nk, maxK=maxK, minK=minK, order=order, int_type=int_type, spin_state=:sigma, kgrid=kgrid, kwargs...)
+            kernel_i = SelfEnergy.LegendreInteraction.DCKernel_Ladder_i(param;
                 Euv=Euv, rtol=rtol, Nk=Nk, maxK=maxK, minK=minK, order=order, int_type=int_type, spin_state=:sigma, kgrid=kgrid, kwargs...)
         end
         G0 = G0wrapped(Euv, rtol, kGgrid, param)
-        Σ, Σ_ins = calcΣ_3d(G0, kernel)
+        Σr, Σ_ins = calcΣ_3d(G0, kernel_r)
+        Σi, Σ_ins = calcΣ_3d(G0, kernel_i)
     else
         error("No support for G0W0 in $dim dimension!")
     end
 
-    return Σ
+    return Σr, Σi
 end
 
 """

--- a/test/galileaninvariance.jl
+++ b/test/galileaninvariance.jl
@@ -1,0 +1,111 @@
+# using ElectronGas
+using Parameters
+using GreenFunc
+using CompositeGrids
+# print(dirname(pwd()))
+include("./ElectronGas.jl/src/convention.jl")
+include("./ElectronGas.jl/src/parameter.jl")
+include("./ElectronGas.jl/src/polarization.jl")
+include("./ElectronGas.jl/src/interaction.jl")
+include("./ElectronGas.jl/src/twopoint.jl")
+using Plots
+
+para = Parameter.rydbergUnit(0.01, 1, 3)
+Ωn_mesh_ph = GreenFunc.ImFreq(para.β, BOSON; Euv=100.0, symmetry=:ph)
+sgrid = 0.0
+
+δladderarray_n = GreenFunc.MeshArray(Ωn_mesh_ph, sgrid; dtype=ComplexF64)
+δTarray_n2 = GreenFunc.MeshArray(Ωn_mesh_ph, sgrid; dtype=ComplexF64)
+
+for (ki, k) in enumerate(sgrid)
+    for (ni, n) in enumerate(Ωn_mesh_ph.grid)
+        δTarray_n2[ni, ki] = Interaction.Tmatrix(k, n, para) - Interaction.T0matrix(k, n, para)
+    end
+end
+
+
+
+
+# Many Body Particle-Particle
+mbladderarray = Polarization.Ladder0_FiniteTemp(0.0, Ωn_mesh_ph.grid, para)
+
+# Vacuum Particle-Particle
+vacladderarray = Polarization.Ladder0_FreeElectron(0.0,  Ωn_mesh_ph.grid, para)
+
+for (ki, k) in enumerate(sgrid)
+    for (ni, n) in enumerate(Ωn_mesh_ph.grid)
+        δladderarray_n[ni, ki] = mbladderarray[ni,ki] - vacladderarray[ni,ki] 
+    end
+end
+
+# for (ki, k) in enumerate(sgrid)
+#     for (ni, n) in enumerate(Ωn_mesh_ph.grid)
+#         δTarray_n[ni, ki] = Interaction.Tmatrix(k, n, para) - Interaction.T0matrix(k, n, para)
+#     end
+# end
+
+δladderarray_τ = δladderarray_n |> to_dlr |> to_imtime
+# δTarray_τ = δTarray_n |> to_dlr |> to_imtime
+
+# Analytic expression for T0(k, τ) #
+
+function T0_τ(q::Float64, τ::Float64, param)
+
+    me, as, μ, β  = param.me, param.as, param.μ, param.β
+    B = me^(3/2) / (4 * π)
+    # Generating a log densed composite grid with LogDensedGrid()
+    ygrid =  CompositeGrid.LogDensedGrid(:gauss,[0.0,50.],[0.0],5,0.005,5)
+
+    # Functions to be integrated 
+    f(y) = ( exp(- y^2 ) * y^2 ) / (τ / (me * as) + y^2)
+    g(y) = ( exp(- y^2 ) * y^2 ) / (τ / (me * as) + y^2) * 1. / ( exp( β * ( y^2/ τ + (q^2 / (4me) - 2μ)) ) - 1)
+
+    # Generate data for integration
+    fdata = [f(y) for (yi, y) in enumerate(ygrid.grid)]
+    gdata = [g(y) for (yi, y) in enumerate(ygrid.grid)]
+
+    fint_result = Interp.integrate1D(fdata, ygrid)
+    gint_result = Interp.integrate1D(gdata, ygrid)
+
+    return exp(-(q^2 / (4 * me) - 2μ) * τ) * (2/( B* π * sqrt(τ) ) * ( fint_result + gint_result ) - exp( τ / (me*as^2) ) / ( 1 - exp( β* ( 1 / (me*as^2) - (q^2 / (4me) - 2μ)) ) ))
+    # return  - exp( τ / (me*as^2) ) / ( 1 - exp( β* ( 1 / (me*as^2) - (q^2 / (4me) - 2μ)) ) )
+
+end
+
+function Σ_τ(q::Float64, param)
+    # Output self energy for the mesh imaginary values
+
+    kgrid = Polarization.finitetemp_kgrid_ladder(param.μ, param.me, q, param.kF, 20, 1e-6, 10)
+    δTarray_n = GreenFunc.MeshArray(Ωn_mesh_ph, kgrid; dtype=ComplexF64)
+
+    for (ki, k) in enumerate(kgrid)
+        for (ni, n) in enumerate(Ωn_mesh_ph.grid)
+            δTarray_n[ni, ki] = Interaction.Tmatrix(k+q, n, param) - Interaction.T0matrix(k+q, n, param)
+        end
+    end
+
+    δTarray_τ = δTarray_n |> to_dlr |> to_imtime
+    integrand = GreenFunc.MeshArray(δTarray_τ, kgrid; dtype=ComplexF64)
+    result = GreenFunc.MeshArray(δTarray_τ.mesh[1]; dtype=ComplexF64)
+
+    for (ti, t) in enumerate(δTarray_τ.mesh[1][:])
+        for (ki, k) in enumerate(kgrid.grid)
+            integrand[ti, ki] = (T0_τ(k + q, t, param) + δTarray_τ[ti]) * exp(t * ( k^2 / (2*param.me)  - param.μ)) * 1 / (exp( param.β * (k^2 / (2* param.me) - param.μ)) + 1)
+        end
+        result[ti] = Interp.integrate1D(integrand[ti, :], kgrid)
+    end
+    return result
+end
+
+qarray = LinRange(0,2*para.kF, 5)
+#test_τ = #[Σ_τ(qi, para) for qi in qarray]
+#test_ω = test_τ |> to_dlr |> to_imfreq
+#plot(test_ω.mesh[1][:], imag(test_ω))
+
+#G0_τ = GreenFunc.MeshArray(test_τ.mesh[1]; dtype=ComplexF64)
+
+#for (ti, t) in enumerate(G0_τ.mesh[1][:])
+#    G0_τ[ti] = T0_τ(0.0, t, para) #exp(t * ( 0.0^2 / (2*para.me)  - para.μ)) * 1 / (exp( para.β * (0.0^2 / (2* para.me) - para.μ)) + 1)
+
+#end
+#G0_ω = G0_τ |> to_dlr |> to_imfreq

--- a/test/ladder.jl
+++ b/test/ladder.jl
@@ -1,9 +1,9 @@
 using MCIntegration
 using ElectronGas
 
-const para = Parameter.rydbergUnit(1.0 / 10, 4.0, 3)
+const para = Parameter.rydbergUnit(1.0 / 100, 1.0, 3)
 const n = 0
-const k = 0.1 * para.kF
+const k = 0.0 * para.kF
 
 function integrand(vars, config)
     n, k, para = config.userdata


### PR DESCRIPTION
Delta T(k, tau) matrix is not smooth

Created routines to calculate the vacuum two-particle T-matrix and many-body T-matrix in Matsubara frequency. The difference between the two in imaginary time is calculated via inverse Fourier transform using the GreensFunc package. Plotting delta T(k, tau), for fixed imaginary time tau, against incoming momentum k does not seem to yield something smooth.

Also added analytic expression for vacuum two-particle T-matrix in imaginary time.